### PR TITLE
test if there is 0, 1 or more LS reason id

### DIFF
--- a/cmd/cluster/support/delete.go
+++ b/cmd/cluster/support/delete.go
@@ -116,17 +116,28 @@ func (o *deleteOptions) run() error {
 	}
 
 	var limitedSupportReasonIds []string
+	limitedSupportReasons, err := getLimitedSupportReasons(o.clusterID)
+
+	if len(limitedSupportReasons) == 0 {
+		fmt.Fprintf(os.Stderr, "Cluster does not has any limited support reason ID \n")
+		os.Exit(1)
+	}
+
 	if o.removeAll {
-		limitedSupportReasons, err := getLimitedSupportReasons(o.clusterID)
 		for _, limitedSupportReason := range limitedSupportReasons {
 			limitedSupportReasonIds = append(limitedSupportReasonIds, limitedSupportReason.ID())
 		}
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to get limited support reasons: %v\n", err)
-			return err
-		}
 	} else {
-		limitedSupportReasonIds = append(limitedSupportReasonIds, o.limitedSupportReasonID)
+		if len(limitedSupportReasons) > 1 && o.limitedSupportReasonID == "" {
+			fmt.Fprintf(os.Stderr, "This cluster has multiple limited support reason IDs. Please specify the exact one \n")
+			os.Exit(1)
+		} else {
+			if len(limitedSupportReasons) == 1 && o.limitedSupportReasonID == "" {
+				limitedSupportReasonIds = append(limitedSupportReasonIds, limitedSupportReasons[0].ID())
+			} else {
+				limitedSupportReasonIds = append(limitedSupportReasonIds, o.limitedSupportReasonID)
+			}
+		}
 	}
 
 	for _, limitedSupportReasonId := range limitedSupportReasonIds {

--- a/cmd/cluster/support/delete.go
+++ b/cmd/cluster/support/delete.go
@@ -129,7 +129,7 @@ func (o *deleteOptions) run() error {
 		}
 	} else {
 		if len(limitedSupportReasons) > 1 && o.limitedSupportReasonID == "" {
-			fmt.Fprintf(os.Stderr, "This cluster has multiple limited support reason IDs. Please specify the exact one \n")
+			fmt.Fprintf(os.Stderr, "This cluster has multiple limited support reason IDs.\nPlease specify the exact reason ID or the `all` flag \n")
 			os.Exit(1)
 		} else {
 			if len(limitedSupportReasons) == 1 && o.limitedSupportReasonID == "" {

--- a/cmd/cluster/support/delete.go
+++ b/cmd/cluster/support/delete.go
@@ -127,17 +127,13 @@ func (o *deleteOptions) run() error {
 		for _, limitedSupportReason := range limitedSupportReasons {
 			limitedSupportReasonIds = append(limitedSupportReasonIds, limitedSupportReason.ID())
 		}
+	} else if len(limitedSupportReasons) > 1 && o.limitedSupportReasonID == "" {
+		fmt.Fprintf(os.Stderr, "This cluster has multiple limited support reason IDs.\nPlease specify the exact reason ID or the `all` flag \n")
+		os.Exit(1)
+	} else if len(limitedSupportReasons) == 1 && o.limitedSupportReasonID == "" {
+		limitedSupportReasonIds = append(limitedSupportReasonIds, limitedSupportReasons[0].ID())
 	} else {
-		if len(limitedSupportReasons) > 1 && o.limitedSupportReasonID == "" {
-			fmt.Fprintf(os.Stderr, "This cluster has multiple limited support reason IDs.\nPlease specify the exact reason ID or the `all` flag \n")
-			os.Exit(1)
-		} else {
-			if len(limitedSupportReasons) == 1 && o.limitedSupportReasonID == "" {
-				limitedSupportReasonIds = append(limitedSupportReasonIds, limitedSupportReasons[0].ID())
-			} else {
-				limitedSupportReasonIds = append(limitedSupportReasonIds, o.limitedSupportReasonID)
-			}
-		}
+		limitedSupportReasonIds = append(limitedSupportReasonIds, o.limitedSupportReasonID)
 	}
 
 	for _, limitedSupportReasonId := range limitedSupportReasonIds {

--- a/cmd/cluster/support/delete.go
+++ b/cmd/cluster/support/delete.go
@@ -67,10 +67,6 @@ func (o *deleteOptions) complete(cmd *cobra.Command, args []string) error {
 		return cmdutil.UsageErrorf(cmd, "Provide exactly one internal cluster ID")
 	}
 
-	if o.limitedSupportReasonID == "" && !o.removeAll {
-		return cmdutil.UsageErrorf(cmd, "Must provide a reason ID or the `all` flag")
-	}
-
 	if o.limitedSupportReasonID != "" && o.removeAll {
 		return cmdutil.UsageErrorf(cmd, "Cannot provide a reason ID with the `all` flag. Please provide one or the other.")
 	}


### PR DESCRIPTION
in response to the issue raised in https://issues.redhat.com/browse/OSD-15383,  this PR 
- allows `cluster support delete` to delete the "only"  LS reason ID in the absence of the `-i` flag
- and if multiple LS reason IDs then, it asks for either a specific LS reason ID or the `-all` flag
